### PR TITLE
Add PrincipalRef to deal with aliases

### DIFF
--- a/lib/krb5.py
+++ b/lib/krb5.py
@@ -177,6 +177,15 @@ class Principal(object):
     def __repr__(self):
         return '<%s: %s>' % (self.__class__.__name__, self.unparse_name())
 
+# A reference to a principal, to avoid freeing
+class PrincipalRef(Principal):
+    def __init__(self, ctx, princ):
+        self._ctx = ctx
+        self._handle = princ
+
+    def __del__(self):
+        pass
+
 class Credentials(object):
     def __init__(self, ctx):
         self._ctx = ctx


### PR DESCRIPTION
Subclass Principal into PrincipalRef to deal with principals that must
not be directly freed by garbage collection, e.g., because they're
aliases into structures such as krb5_enc_tkt_part.

Pull 3 of a series of 3. Check out my wip branch for all of them on one branch.
